### PR TITLE
Fix watch mode and fail on table schema duplicates

### DIFF
--- a/src/parse-file.ts
+++ b/src/parse-file.ts
@@ -37,7 +37,7 @@ export function parseFile (filePath: string) {
       if (!importSpecifier) return
 
       if (importSpecifier.node.name === "defineTable") {
-        tableSchemas.push(parseTableDefinition(path))
+        tableSchemas.push(parseTableDefinition(path, filePath))
       }
     },
     TaggedTemplateExpression (path) {

--- a/src/parse-table-definition.ts
+++ b/src/parse-table-definition.ts
@@ -5,6 +5,7 @@ import * as types from "@babel/types"
 export interface TableSchema {
   tableName: string,
   columnNames: string[],
+  filePath: string,
   loc: types.SourceLocation | null
 }
 
@@ -31,7 +32,7 @@ function parseTableColumnsDefinition (path: NodePath<types.ObjectExpression>) {
   }
 }
 
-export function parseTableDefinition (path: NodePath<types.CallExpression>): TableSchema {
+export function parseTableDefinition (path: NodePath<types.CallExpression>, filePath: string): TableSchema {
   const args = path.get("arguments")
   if (args.length !== 2) throw path.buildCodeFrameError("Expected two arguments on defineTable() call.")
 
@@ -45,6 +46,7 @@ export function parseTableDefinition (path: NodePath<types.CallExpression>): Tab
   return {
     tableName,
     columnNames,
+    filePath,
     loc: path.node.loc
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -37,7 +37,7 @@ function assertIntactUnqualifiedColumnRef (columnRef: UnqualifiedColumnReference
   }
   if (inScopeSchemasContainingColumn.length > 1) {
     throw new Error(
-      `Unqualified column reference "${columnRef.columnName}" matches more than one referenced table:` +
+      `Unqualified column reference "${columnRef.columnName}" matches more than one referenced table: ` +
       inScopeSchemasContainingColumn.map(schema => schema.tableName).join(", ")
     )
   }


### PR DESCRIPTION
Watch mode didn't work when watching more than one file, since it would only re-parse the changed file and consider only the re-parsed table schemas, not the schemas defined in unchanged files.

Will also fail now if you define the same table more than once (across all source files).