### PR TITLE
Show source code in code frames

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ function checkSchemasForDuplicates (allTableSchemas: TableSchema[]) {
         `Table ${schema.tableName} has been defined more than once:\n` +
         schemasMatchingThatName.map(duplicate => {
           const lineRef = duplicate.loc ? `:${duplicate.loc.start.line}` : ``
-          return `  - ${duplicate.filePath}${lineRef}`
+          return `  - ${duplicate.sourceFile.filePath}${lineRef}`
         }).join("\n")
       )
     }
@@ -96,7 +96,7 @@ if (watchMode) {
   console.log(`\nWatching file changes... Press CTRL + C to cancel.\n`)
 
   chokidar.watch(cli.input).on("all", (event, filePath) => {
-    const schemasInOtherFiles = schemas.filter(schema => schema.filePath !== filePath)
+    const schemasInOtherFiles = schemas.filter(schema => schema.sourceFile.filePath !== filePath)
     const lastRunResult = run([ filePath ], schemasInOtherFiles)
 
     schemas = lastRunResult.schemas

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,14 +3,17 @@ import { ParsingError } from "pg-query-parser"
 import * as format from "./format"
 import { Query } from "./parse-file"
 import { QueryNodePath } from "./query-parser-utils"
+import { SourceFile } from "./types"
 
 export interface SyntaxError extends Error {
-  location: number
+  location: SourceLocation,
+  sourceFile: SourceFile
 }
 
 export interface ValidationError extends Error {
-  location?: number
-  path: QueryNodePath<any>
+  location: SourceLocation,
+  path: QueryNodePath<any>,
+  sourceFile: SourceFile
 }
 
 export function fail (message: string): never {
@@ -28,13 +31,36 @@ function formatSourceLink (filePath: string, location?: SourceLocation | null): 
   }
 }
 
-function translateIndexToSourceLocation (text: string, index: number): SourceLocation["start"] {
-  const linesUntilIndex = text.substring(0, index).split("\n")
-  const line = linesUntilIndex.length
-  const column = linesUntilIndex[linesUntilIndex.length - 1].length
+function getOverallSourceLocation (locations: SourceLocation[]): SourceLocation {
+  const first = locations[0]
+  const last = locations[locations.length - 1]
   return {
-    line,
-    column
+    start: {
+      column: first.start.column,
+      line: first.start.line
+    },
+    end: {
+      column: last.start.column,
+      line: last.start.line
+    }
+  }
+}
+
+function mapToSourceLocation (query: Query, stringIndex: number): SourceLocation {
+  const matchingSpan = query.sourceMap.find(span => span.queryStartIndex <= stringIndex && span.queryEndIndex > stringIndex)
+  if (!matchingSpan) return getOverallSourceLocation(query.sourceMap.map(span => span.sourceLocation))
+
+  const indexInSpan = stringIndex - matchingSpan.queryStartIndex
+  const preceedingTextInSpan = query.query.substring(matchingSpan.queryStartIndex, stringIndex)
+
+  const lineIndexInSpan = preceedingTextInSpan.replace(/[^\n]/g, "").length
+  const columnIndexInSpan = indexInSpan - preceedingTextInSpan.lastIndexOf("\n")
+
+  return {
+    start: {
+      column: lineIndexInSpan > 0 ? columnIndexInSpan : matchingSpan.sourceLocation.start.column + columnIndexInSpan,
+      line: matchingSpan.sourceLocation.start.line + lineIndexInSpan
+    }
   }
 }
 
@@ -43,30 +69,38 @@ export function isAugmentedError (error: Error | SyntaxError | ValidationError) 
 }
 
 export function augmentFileValidationError (error: Error | SyntaxError | ValidationError, query: Query) {
-  const formattedQuery = "location" in error && error.location && error.location > 0
-    ? codeFrameColumns(query.query, { start: translateIndexToSourceLocation(query.query, error.location) })
-    : query
+  const location = "location" in error && error.location
+    ? error.location
+    : getOverallSourceLocation(query.sourceMap.map(span => span.sourceLocation))
+
+  const formattedQuery = codeFrameColumns(query.sourceFile.fileContent, location)
 
   error.name = "ValidationError"
   error.message = (
-    format.error(`Query validation failed in ${formatSourceLink(query.sourceFile.filePath, query.loc)}:`) + `\n\n` +
+    format.error(`Query validation failed in ${formatSourceLink(query.sourceFile.filePath, location)}:`) + `\n\n` +
     format.error(`${error.message}`) + `\n\n` +
     formattedQuery
   )
   return error
 }
 
-export function augmentQuerySyntaxError (error: Error, syntaxError: ParsingError): SyntaxError {
+export function augmentQuerySyntaxError (error: Error, syntaxError: ParsingError, query: Query): SyntaxError {
   return Object.assign(error as SyntaxError, {
     name: "QuerySyntaxError",
-    location: syntaxError.cursorPosition
+    location: mapToSourceLocation(query, syntaxError.cursorPosition - 1),
+    sourceFile: query.sourceFile
   })
 }
 
-export function augmentValidationError (error: Error, path: QueryNodePath<any>): ValidationError {
+export function augmentValidationError (error: Error, path: QueryNodePath<any>, query: Query): ValidationError {
+  const location = path.type in path.node && "location" in path.node[path.type]
+    ? mapToSourceLocation(query, path.node[path.type].location)
+    : undefined
+
   return Object.assign(error as ValidationError, {
-    location: path.type in path.node && "location" in path.node[path.type] ? path.node[path.type].location + 1 : undefined,
     name: "ValidationError",
-    path
+    path,
+    location,
+    sourceFile: query.sourceFile
   })
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -49,7 +49,7 @@ export function augmentFileValidationError (error: Error | SyntaxError | Validat
 
   error.name = "ValidationError"
   error.message = (
-    format.error(`Query validation failed in ${formatSourceLink(query.filePath, query.loc)}:`) + `\n\n` +
+    format.error(`Query validation failed in ${formatSourceLink(query.sourceFile.filePath, query.loc)}:`) + `\n\n` +
     format.error(`${error.message}`) + `\n\n` +
     formattedQuery
   )

--- a/src/parse-file.ts
+++ b/src/parse-file.ts
@@ -26,9 +26,11 @@ function compileTypeScript (filePath: string) {
 }
 
 function instantiateSourceFile (filePath: string): SourceFile {
+  const fileContent = fs.readFileSync(filePath, "utf8")
   const program = filePath.endsWith(".ts") ? compileTypeScript(filePath) : undefined
 
   return {
+    fileContent,
     filePath,
     ts: program ? {
       program,
@@ -42,14 +44,11 @@ export function parseFile (filePath: string) {
   const queries: Query[] = []
   const tableSchemas: TableSchema[] = []
 
-  const isTypescript = filePath.endsWith(".ts")
-  const content = fs.readFileSync(filePath, "utf8")
-
   const sourceFile = instantiateSourceFile(filePath)
 
-  const ast = parse(content, {
+  const ast = parse(sourceFile.fileContent, {
     filename: filePath,
-    plugins: isTypescript ? ["@babel/plugin-transform-typescript"] : [],
+    plugins: sourceFile.ts ? ["@babel/plugin-transform-typescript"] : [],
     sourceType: "unambiguous"
   })
 

--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -88,7 +88,7 @@ function parsePostgresQuery (queryString: string, path: NodePath<types.TemplateL
   const result = QueryParser.parse(queryString)
 
   if (result.error) {
-    const error = new Error(`Syntax error in SQL query.`)
+    const error = new Error(`Syntax error in SQL query.\nSubstituted query: ${queryString.trim()}`)
     const query: Query = {
       query: queryString,
       referencedColumns: [],

--- a/src/parse-table-definition.ts
+++ b/src/parse-table-definition.ts
@@ -1,13 +1,8 @@
 import { NodePath } from "@babel/traverse"
 import * as types from "@babel/types"
+import { SourceFile, TableSchema } from "./types"
 
 // TODO: Parse column types as well
-export interface TableSchema {
-  tableName: string,
-  columnNames: string[],
-  filePath: string,
-  loc: types.SourceLocation | null
-}
 
 function parseTableColumnsDefinition (path: NodePath<types.ObjectExpression>) {
   const columnNames = path.get("properties").reduce(
@@ -32,7 +27,7 @@ function parseTableColumnsDefinition (path: NodePath<types.ObjectExpression>) {
   }
 }
 
-export function parseTableDefinition (path: NodePath<types.CallExpression>, filePath: string): TableSchema {
+export function parseTableDefinition (path: NodePath<types.CallExpression>, sourceFile: SourceFile): TableSchema {
   const args = path.get("arguments")
   if (args.length !== 2) throw path.buildCodeFrameError("Expected two arguments on defineTable() call.")
 
@@ -46,7 +41,7 @@ export function parseTableDefinition (path: NodePath<types.CallExpression>, file
   return {
     tableName,
     columnNames,
-    filePath,
-    loc: path.node.loc
+    loc: path.node.loc,
+    sourceFile
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,46 @@
+import * as types from "@babel/types"
+import * as ts from "typescript"
+import { QueryNodePath } from "./query-parser-utils"
+
+export interface SourceFile {
+  filePath: string,
+  ts?: {
+    program: ts.Program,
+    sourceFile: ts.SourceFile
+  }
+}
+
+export interface TableSchema {
+  sourceFile: SourceFile,
+  tableName: string,
+  columnNames: string[],
+  loc: types.SourceLocation | null
+}
+
+export interface TableReference {
+  tableName: string,
+  as?: string,
+  path: QueryNodePath<any>
+}
+
+export interface QualifiedColumnReference {
+  tableName: string,
+  columnName: string,
+  path: QueryNodePath<any>
+}
+
+export interface UnqualifiedColumnReference {
+  tableRefsInScope: TableReference[],
+  columnName: string,
+  path: QueryNodePath<any>
+}
+
+export type ColumnReference = QualifiedColumnReference | UnqualifiedColumnReference
+
+export interface Query {
+  sourceFile: SourceFile,
+  query: string,
+  referencedColumns: ColumnReference[],
+  referencedTables: TableReference[],
+  loc: types.SourceLocation | null
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import * as ts from "typescript"
 import { QueryNodePath } from "./query-parser-utils"
 
 export interface SourceFile {
+  fileContent: string,
   filePath: string,
   ts?: {
     program: ts.Program,
@@ -37,10 +38,16 @@ export interface UnqualifiedColumnReference {
 
 export type ColumnReference = QualifiedColumnReference | UnqualifiedColumnReference
 
+export interface QuerySourceMapSpan {
+  sourceLocation: types.SourceLocation,
+  queryStartIndex: number,
+  queryEndIndex: number
+}
+
 export interface Query {
   sourceFile: SourceFile,
+  sourceMap: QuerySourceMapSpan[],
   query: string,
   referencedColumns: ColumnReference[],
-  referencedTables: TableReference[],
-  loc: types.SourceLocation | null
+  referencedTables: TableReference[]
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,6 +1,5 @@
 import { augmentFileValidationError, augmentValidationError } from "./errors"
-import { Query, QualifiedColumnReference, UnqualifiedColumnReference, TableReference } from "./parse-query"
-import { TableSchema } from "./parse-table-definition"
+import { Query, QualifiedColumnReference, UnqualifiedColumnReference, TableReference, TableSchema } from "./types"
 
 function assertIntactQualifiedColumnRef (columnRef: QualifiedColumnReference, tables: TableSchema[]) {
   const table = tables.find(someTable => someTable.tableName === columnRef.tableName)

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -60,7 +60,7 @@ export function assertNoBrokenColumnRefs (query: Query, tables: TableSchema[]) {
           assertIntactUnqualifiedColumnRef(columnRef, tables)
         }
       } catch (error) {
-        throw augmentValidationError(error, columnRef.path)
+        throw augmentValidationError(error, columnRef.path, query)
       }
     }
   } catch (error) {
@@ -74,7 +74,7 @@ export function assertNoBrokenTableRefs (query: Query, tables: TableSchema[]) {
       try {
         assertIntactTableRef(tableRef, tables)
       } catch (error) {
-        throw augmentValidationError(error, tableRef.path)
+        throw augmentValidationError(error, tableRef.path, query)
       }
     }
   } catch (error) {


### PR DESCRIPTION
Show the original source code, not just the (already preprocessed) query.